### PR TITLE
Corrected the run server syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Set the listening port (example: 5555) and start the server from the project roo
 ### Dev / LAN (self-hosted):
 
 ```bash
-bin/python -m streampilot -port 5555 -name "John Dear" -max_streamhubs 4  -max_srtgateway 2 -user 'admin' -password 'password'
+bin/python streampilot/server.py -port 5555 -name "John Dear" -max_streamhubs 4  -max_srtgateway 2 -user 'admin' -password 'password'
 ```
 
 ### Behind Nginx in HTTPS (proxy):


### PR DESCRIPTION
The bin/python -m streampilot ... command does not work with the current repository layout, as streampilot is not an executable Python module. The server must be started via streampilot/server.py.