### PR TITLE
Fix CLI argument parsing during startup

### DIFF
--- a/streampilot/server.py
+++ b/streampilot/server.py
@@ -5638,12 +5638,12 @@ def _parse_cli():
         allow_abbrev=False
     )
     
-    parser.add_argument('-port,','--port')
-    parser.add_argument('-name','--name')
-    parser.add_argument('-user','--user')
-    parser.add_argument('-password','--password')
-    parser.add_argument('-max_streamhub','--max_streamhub')
-    parser.add_argument('-max_srtgateway','--max_srtgateway')
+    parser.add_argument('-port')
+    parser.add_argument('-name')
+    parser.add_argument('-user')
+    parser.add_argument('-password')
+    parser.add_argument('-max_streamhub')
+    parser.add_argument('-max_srtgateway')
     args = parser.parse_args()
     return args
 

--- a/streampilot/server.py
+++ b/streampilot/server.py
@@ -5629,8 +5629,39 @@ async function repoll(){
             c.execute("UPDATE srt_gw_slack SET notify_paused=0 WHERE gw_id=?", (gid,))
         raise cherrypy.HTTPRedirect("/settings?msg=SRT+Gateway+notifications+resumed")
 
+def _parse_cli():
+    # Parse CLI args and push them into env vars before anything reads them
+    import argparse
 
+    parser = argparse.ArgumentParser(
+        add_help=False,
+        allow_abbrev=False
+    )
+    
+    parser.add_argument('-port,','--port')
+    parser.add_argument('-name','--name')
+    parser.add_argument('-user','--user')
+    parser.add_argument('-password','--password')
+    parser.add_argument('-max_streamhub','--max_streamhub')
+    parser.add_argument('-max_srtgateway','--max_srtgateway')
+    args = parser.parse_args()
+    return args
+
+def _apply_cli_env(args):
+    # Runtime flags (always allowed)
+    if args.port:
+        os.environ['SP_PORT'] = args.port
+    if args.name:
+        os.environ['CLIENT_NAME'] = args.name
+    if args.max_streamhub:
+        os.environ['MAX_STREAMHUB'] = args.max_streamhub
+    if args.max_srtgateway:
+        os.environ['MAX_SRTGATEWAY'] = args.max_srtgateway
+    
 def run():
+    args = _parse_cli()
+    _apply_cli_env(args)
+    
     _init_db()  # create tables/indexes once at startup
     # Attach CORS headers to every response (including 3xx redirects)
     def _cors():


### PR DESCRIPTION
Add parsing in server.py so flags like port and limits are correctly honored when running. i.e.: `python -m streampilot -port 8080 -name StreamPilot -max_streamhub 4  -max_srtgateway 4`.

Also, removed trailing 's' from the -max_streamhub option.

Note: Parts of this change were generated with M365 Copilot AI. I reviewed the code and validated it through testing.